### PR TITLE
Containerize worker

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -18,5 +18,5 @@
 [tool]
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.0.1"
+version = "1.0.0"
 tag_format = "$version"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# The directory Mix will write compiled artifacts to.
+_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+cover/
+
+# The directory Mix downloads your dependencies sources to.
+deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Developer tools
+.git
+.tool-versions
+
+# Umbrella
+apps/**/config/*.secret.exs
+apps/**/node_modules
+apps/**/priv/static
+
+# Docker
+.dockerignore
+Dockerfile
+docker-compose.yml
+
+# Secrets
+apps/*/priv/secrets/*
+!apps/*/priv/secrets/.keep
+
+# File types
+tmp
+erl_crash.dump
+*.ez
+

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,48 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Container
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build and push Docker images
+      uses: docker/build-push-action@v3.0.0
+      with:
+        context: .
+        push: true
+        tags: ghcr.io/funlessdev/fl-worker:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+## 1.0.0 (2022-06-07)
+
+### Refactor
+
+- **check.yml**: rename ci tasks
+- rewrite worker application following hexagonal architecture
+- move genserver to separate file; merge worker and function
+- refactor worker as genserver; add updater for state preservation in ets
+- **Worker**: refactor worker as an elixir application
+- **.gitignore**: fix target/ directory not being ignored correctly
+- **fn**: move rust code to native/fn directory
+- delete fn submodule
+- **license**: add license header to atoms.rs
+- **funless-fn**: move submodule from funless-fn to fn
+- **license**: add license header to nif.rs
+- move get_image and start_container out of setup_container
+
+### Fix
+
+- **api.ex**: add check in cleanup
+- **license**: add license header to tests; ignore eex files in license checks
+- fix rustler init and return types
+
+### Feat
+
+- **worker.ex**: add invoke_function
+- add support for default docker installation
+- **worker.ex**: add basic worker behaviour
+- parameterize all NIFs; handle messages from NIFs' environment
+- **nif.rs**: parameterize all NIFs; move all NIFs to non-BEAM thread
+- add funless-fn NIF module
+- **nif.rs**: implement run_function() and cleanup() NIFs
+- create project with funless-fn submodule
+- **nif.rs**: add initial rustler integration
+- execute external code inside container
+- add initial bollard functions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+FROM elixir:1.13.4 as build
+
+# install build dependencies
+RUN apt-get update && apt-get install -y build-essential curl
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+RUN mkdir /app
+WORKDIR /app
+
+# install Hex + Rebar
+RUN mix do local.hex --force, local.rebar --force
+
+# set build ENV
+ENV MIX_ENV=prod
+
+COPY . .
+
+# COPY config config
+RUN mix deps.get --only $MIX_ENV
+RUN mix deps.compile
+
+RUN mix compile
+
+# build release
+# at this point we should copy the rel directory but
+# we are not using it so we can omit it
+# COPY rel rel
+RUN mix release
+
+# prepare release image
+# FROM elixir:1.13.4-alpine AS app
+
+# # install runtime dependencies
+# RUN apk add --update bash openssl-dev
+
+# EXPOSE 4000
+# ENV MIX_ENV=prod
+
+# # prepare app directory
+# RUN mkdir /app
+# WORKDIR /app
+
+# # copy release to app container
+# COPY --from=build /app/_build/prod/rel/core .
+# RUN chown -R nobody: /app
+# USER nobody
+
+ENV HOME=/app
+CMD ["bash", "_build/prod/rel/worker/bin/worker", "start"]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import Config
+config :worker, Worker.Domain.Ports.Containers, adapter: Worker.Adapters.Containers.Docker
+
+config :worker, Worker.Domain.Ports.FunctionStorage, adapter: Worker.Adapters.FunctionStorage.ETS


### PR DESCRIPTION
Add dockerfile to create new image of worker project with prod config.
Add new github action to publish new image from main branch.

This PR bumps version to 1.0.0 since now worker is able to receive invoke messages, run a sample function and is able to
be easily deployed as a container.