### PR TITLE
Fix for pull image and refactor for logging

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -18,7 +18,7 @@
 [tool]
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.1.0"
+version = "1.1.1"
 tag_format = "v$version"
 annotated_tag = true
 version_files = ["mix.exs"]

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,8 +17,10 @@
 #
 
 import Config
-config :worker, Worker.Domain.Ports.Containers, adapter: Worker.Adapters.Containers.Docker
 
+config :worker, Worker.Domain.Ports.Containers, adapter: Worker.Adapters.Containers.Docker
 config :worker, Worker.Domain.Ports.FunctionStorage, adapter: Worker.Adapters.FunctionStorage.ETS
+
+config :logger, :console, format: "\n##### $time $metadata[$level] $levelpad$message\n"
 
 import_config "#{Mix.env()}.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -17,6 +17,9 @@
 #
 
 import Config
-config :worker, Worker.Domain.Ports.Containers, adapter: Worker.Adapters.Containers.Docker
 
-config :worker, Worker.Domain.Ports.FunctionStorage, adapter: Worker.Adapters.FunctionStorage.ETS
+config :logger,
+  backends: [:console],
+  compile_time_purge_matching: [
+    [level_lower_than: :info]
+  ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,6 +17,9 @@
 #
 
 import Config
-config :worker, Worker.Domain.Ports.Containers, adapter: Worker.Containers.Mock
 
+config :worker, Worker.Domain.Ports.Containers, adapter: Worker.Containers.Mock
 config :worker, Worker.Domain.Ports.FunctionStorage, adapter: Worker.FunctionStorage.Mock
+
+# Print only warnings and errors during test
+config :logger, level: :warn

--- a/lib/worker/adapters/containers/docker.ex
+++ b/lib/worker/adapters/containers/docker.ex
@@ -23,6 +23,8 @@ defmodule Worker.Adapters.Containers.Docker do
   @behaviour Worker.Domain.Ports.Containers
   alias Worker.Nif.Fn
 
+  require Logger
+
   @doc """
     Checks the DOCKER_HOST environment variable for the docker socket path. If an incorrect path is found, the default is used instead.
 
@@ -57,6 +59,8 @@ defmodule Worker.Adapters.Containers.Docker do
         container_name
       ) do
     socket = docker_socket()
+
+    Logger.info("Containers: Creating container for function '#{worker_function.name}'")
 
     Fn.prepare_container(
       worker_function,
@@ -99,6 +103,8 @@ defmodule Worker.Adapters.Containers.Docker do
     body = Jason.encode!(%{"value" => args})
 
     request = {"http://#{host}:#{port}/run", [], ["application/json"], body}
+
+    Logger.info("Containers: Running function on container #{host}:#{port}")
     response = :httpc.request(:post, request, [], [])
     response
   end

--- a/lib/worker/adapters/containers/docker.ex
+++ b/lib/worker/adapters/containers/docker.ex
@@ -103,8 +103,6 @@ defmodule Worker.Adapters.Containers.Docker do
     body = Jason.encode!(%{"value" => args})
 
     request = {"http://#{host}:#{port}/run", [], ["application/json"], body}
-
-    Logger.info("Containers: Running function on container #{host}:#{port}")
     response = :httpc.request(:post, request, [], [])
     response
   end

--- a/lib/worker/adapters/function_storage/ets/writeserver.ex
+++ b/lib/worker/adapters/function_storage/ets/writeserver.ex
@@ -40,14 +40,14 @@ defmodule Worker.Adapters.FunctionStorage.ETS.WriteServer do
   @impl true
   def handle_call({:insert, function_name, container}, _from, table) do
     :ets.insert(table, {function_name, container})
-    Logger.info("Function Storage Server: inserted #{function_name} => #{container}")
+    Logger.info("Function Storage Server: added #{function_name} => #{container.name}")
     {:reply, {:ok, {function_name, container}}, table}
   end
 
   @impl true
   def handle_call({:delete, function_name, container}, _from, table) do
     :ets.delete_object(table, {function_name, container})
-    Logger.info("Function Storage Server: deleted #{function_name} => #{container}")
+    Logger.info("Function Storage Server: deleted #{function_name} => #{container.name}")
     {:reply, {:ok, {function_name, container}}, table}
   end
 end

--- a/lib/worker/adapters/function_storage/ets/writeserver.ex
+++ b/lib/worker/adapters/function_storage/ets/writeserver.ex
@@ -24,6 +24,7 @@ defmodule Worker.Adapters.FunctionStorage.ETS.WriteServer do
     :functions_containers.
   """
   use GenServer, restart: :permanent
+  require Logger
 
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: :write_server)
@@ -32,19 +33,21 @@ defmodule Worker.Adapters.FunctionStorage.ETS.WriteServer do
   @impl true
   def init(_args) do
     table = :ets.new(:functions_containers, [:named_table, :protected])
-    IO.puts("FunctionStorage server running")
+    Logger.info("Function Storage Server: started")
     {:ok, table}
   end
 
   @impl true
   def handle_call({:insert, function_name, container}, _from, table) do
     :ets.insert(table, {function_name, container})
+    Logger.info("Function Storage Server: inserted #{function_name} => #{container}")
     {:reply, {:ok, {function_name, container}}, table}
   end
 
   @impl true
   def handle_call({:delete, function_name, container}, _from, table) do
     :ets.delete_object(table, {function_name, container})
+    Logger.info("Function Storage Server: deleted #{function_name} => #{container}")
     {:reply, {:ok, {function_name, container}}, table}
   end
 end

--- a/lib/worker/adapters/requests/cluster/cluster.ex
+++ b/lib/worker/adapters/requests/cluster/cluster.ex
@@ -49,12 +49,13 @@ defmodule Worker.Adapters.Requests.Cluster do
     GenServer.reply(from, result)
   end
 
+  @doc false
   defp run_with_container(true, function, args) do
     Api.run_function(function, args)
   end
 
   defp run_with_container(false, function, args) do
-    Logger.warn("Cluster: no container found for function #{function.name}")
+    Logger.warn("Worker: no container found for function #{function.name}")
 
     case Api.prepare_container(function) do
       {:ok, _} ->

--- a/lib/worker/adapters/requests/cluster/server.ex
+++ b/lib/worker/adapters/requests/cluster/server.ex
@@ -45,6 +45,7 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
 
   @impl true
   def handle_call({:invoke, function}, from, _state) do
+    Logger.info("Worker: received invocation for #{function.name}.")
     spawn(Cluster, :invoke, [function, %{}, from])
     {:noreply, nil}
   end

--- a/lib/worker/adapters/requests/cluster/server.ex
+++ b/lib/worker/adapters/requests/cluster/server.ex
@@ -24,6 +24,8 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
   use GenServer, restart: :permanent
   alias Worker.Adapters.Requests.Cluster
 
+  require Logger
+
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: :worker)
   end
@@ -31,7 +33,7 @@ defmodule Worker.Adapters.Requests.Cluster.Server do
   @impl true
   def init(_args) do
     # Process.flag(:trap_exit, true)
-    IO.puts("Worker Server running")
+    Logger.info("Worker Server: started")
     {:ok, nil}
   end
 

--- a/lib/worker/domain/api.ex
+++ b/lib/worker/domain/api.ex
@@ -82,7 +82,7 @@ defmodule Worker.Domain.Api do
   @doc """
     Creates a container for the given function; in case of successful creation, the {function, container} couple is inserted in the function storage.
 
-    Returns {:ok, container} if the container is created, otherwise forwards {:error, err} from the Containers implementation.
+    Returns {:ok, container.name} if the container is created, otherwise forwards {:error, err} from the Containers implementation.
 
     ## Parameters
       - %{...}: generic struct with all the fields required by Worker.Domain.Function

--- a/lib/worker/domain/api.ex
+++ b/lib/worker/domain/api.ex
@@ -167,7 +167,7 @@ defmodule Worker.Domain.Api do
   @doc """
     Removes the first container associated with the given function.
 
-    Returns {:ok, container} if the cleanup is successful;
+    Returns {:ok, container_name} if the cleanup is successful;
     returns {:error, err} if any error is encountered (both while removing the container and when searching for it).
 
     ## Parameters

--- a/lib/worker/domain/api.ex
+++ b/lib/worker/domain/api.ex
@@ -61,18 +61,18 @@ defmodule Worker.Domain.Api do
   alias Worker.Domain.Ports.Containers
   alias Worker.Domain.Ports.FunctionStorage
 
+  require Elixir.Logger
+
   @doc """
     Checks if the function with the given `function_name` has an associated container in the underlying function storage.
 
-    Returns true if containers are found, false otherwise.
+    Returns true, [containers] if containers are found, false, [] otherwise.
 
     ## Parameters
       - %{name: function_name}: generic struct with a `name` field, containing the function name
   """
-  @spec function_has_container?(Struct.t()) :: Boolean.t()
-  def function_has_container?(%{
-        name: function_name
-      }) do
+  @spec function_has_containers?(Struct.t()) :: boolean()
+  def function_has_containers?(%{name: function_name}) do
     case FunctionStorage.get_function_containers(function_name) do
       {:ok, _} -> true
       {:error, _} -> false
@@ -94,8 +94,6 @@ defmodule Worker.Domain.Api do
         archive: archive_name,
         main_file: main_file
       }) do
-    container_name = function_name <> "-funless-container"
-
     function = %Worker.Domain.Function{
       name: function_name,
       image: image_name,
@@ -103,16 +101,24 @@ defmodule Worker.Domain.Api do
       main_file: main_file
     }
 
-    result = Containers.prepare_container(function, container_name)
+    container_name = function_name <> "-funless-container"
 
-    case result do
-      {:ok, container = %Worker.Domain.Container{name: container_name}} ->
-        FunctionStorage.insert_function_container(function_name, container)
-        {:ok, container_name}
+    Containers.prepare_container(function, container_name)
+    |> store_prepared_container(function_name)
+  end
 
-      _ ->
-        result
-    end
+  defp store_prepared_container(
+         {:ok, container = %Worker.Domain.Container{name: container_name}},
+         function_name
+       ) do
+    Logger.info("API: Container prepared #{container_name}")
+    FunctionStorage.insert_function_container(function_name, container)
+    {:ok, container_name}
+  end
+
+  defp store_prepared_container({:error, err}, _) do
+    Logger.error("API: Container preparation failed: #{err}")
+    {:error, err}
   end
 
   @doc """
@@ -144,15 +150,18 @@ defmodule Worker.Domain.Api do
       main_file: main_file
     }
 
-    containers = FunctionStorage.get_function_containers(function_name)
+    FunctionStorage.get_function_containers(function_name)
+    |> run_function_with_container(function, args)
+  end
 
-    case containers do
-      {:ok, {_, [container | _]}} ->
-        Containers.run_function(function, args, container)
+  defp run_function_with_container({:ok, {_, [container | _]}}, function, args) do
+    Logger.info("API: Running function #{function.name} with container: #{container.name}")
+    Containers.run_function(function, args, container)
+  end
 
-      {:error, err} ->
-        {:error, {:nocontainer, err}}
-    end
+  defp run_function_with_container({:error, err}, _, _) do
+    Logger.error("API: Error running function: #{err}")
+    {:error, err}
   end
 
   @doc """

--- a/lib/worker/domain/api.ex
+++ b/lib/worker/domain/api.ex
@@ -66,7 +66,7 @@ defmodule Worker.Domain.Api do
   @doc """
     Checks if the function with the given `function_name` has an associated container in the underlying function storage.
 
-    Returns true, [containers] if containers are found, false, [] otherwise.
+    Returns true if containers are found, false otherwise.
 
     ## Parameters
       - %{name: function_name}: generic struct with a `name` field, containing the function name

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule FunlessWorker.MixProject do
   def project do
     [
       app: :worker,
-      version: "1.1.0",
+      version: "1.1.1",
       elixir: "~> 1.13",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/native/fn/src/utils.rs
+++ b/native/fn/src/utils.rs
@@ -48,7 +48,7 @@ pub fn connect_to_docker(docker_path: &str) -> Result<Docker, Error> {
 /// * `image_name` -  A string slice holding the short name for the Docker image
 pub fn select_image(image_name: &str) -> Option<&str> {
     match image_name {
-        "nodejs" => Some("openwhisk/action-nodejs-v16"),
+        "nodejs" => Some("openwhisk/action-nodejs-v16:latest"),
         _ => None,
     }
 }

--- a/test/api_test.exs
+++ b/test/api_test.exs
@@ -83,14 +83,12 @@ defmodule ApiTest do
       assert {:ok, "output"} == Api.run_function(function)
     end
 
-    test "run_function should return {:error, {:nocontainer, err}} when no container is found for the given function",
+    test "run_function should return {:error, err} when no container is found for the given function",
          %{function: function} do
       Worker.FunctionStorage.Mock
-      |> Mox.stub(:get_function_containers, fn _function_name ->
-        {:error, "generic error"}
-      end)
+      |> Mox.stub(:get_function_containers, fn _function_name -> {:error, "nocontainer error"} end)
 
-      assert {:error, {:nocontainer, "generic error"}} == Api.run_function(function)
+      assert {:error, "nocontainer error"} == Api.run_function(function)
     end
 
     test "run_function should return {:error, err} when running the given function raises an error",

--- a/test/function_storage_test.exs
+++ b/test/function_storage_test.exs
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+defmodule FunctionStorageTest do
+  use ExUnit.Case, async: true
+  alias Worker.Adapters.FunctionStorage.ETS
+  import Mox, only: [verify_on_exit!: 1]
+
+  setup :verify_on_exit!
+
+  test "get_function_containers returns an error when no containers stored" do
+    result = ETS.get_function_containers("test-no-container")
+    assert result == {:error, "no container found for test-no-container"}
+  end
+
+  test "insert_function_container adds {function_name, container} couple to the storage" do
+    container = %Worker.Domain.Container{
+      host: "127.0.0.1",
+      port: "8080",
+      name: "test-container"
+    }
+
+    ETS.insert_function_container("test", container)
+
+    assert ETS.get_function_containers("test") == {:ok, {"test", [container]}}
+  end
+
+  test "delete_function_container removes a {function_name, container} couple from the storage" do
+    container = %Worker.Domain.Container{
+      host: "127.0.0.1",
+      port: "8080",
+      name: "test-container"
+    }
+
+    ETS.insert_function_container("test-delete", container)
+
+    ETS.delete_function_container("test-delete", container)
+
+    assert ETS.get_function_containers("test-delete") ==
+             {:error, "no container found for test-delete"}
+  end
+end


### PR DESCRIPTION
Small refactor to divide bigger functions in smaller functions so it was easier to not clutter the code of logs but keep single log lines in the appropriate places.