### PR TITLE
Start phase to connect to a core node using env var

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -42,11 +42,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Set APP_VSN arg value
-        run: |
-          VERSION=${{github.ref_name}} 
-          echo "VERSION=${VERSION:1}" >> $GITHUB_ENV
-
       - name: Build and push Docker images
         uses: docker/build-push-action@v3.0.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,11 +60,13 @@ RUN apk update && \
 
 ENV REPLACE_OS_VARS=true \
     APP_NAME=${APP_NAME} \
-    MIX_ENV=${MIX_ENV}
+    MIX_ENV=${MIX_ENV} 
+
+ARG CORE
 
 WORKDIR /opt/app
 
 COPY --from=builder /opt/app/_build/${MIX_ENV}/rel/${APP_NAME} .
 
 EXPOSE 4001
-CMD trap 'exit' INT; /opt/app/bin/${APP_NAME} start
+CMD trap 'exit' INT; CORE=${CORE} /opt/app/bin/${APP_NAME} start

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,4 +18,6 @@
 
 import Config
 
-config :worker, core: System.fetch_env!("CORE")
+if config_env() == :prod do
+  config :worker, core: System.fetch_env!("CORE")
+end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -18,11 +18,4 @@
 
 import Config
 
-config :worker, Worker.Domain.Ports.Runtime, adapter: Worker.Adapters.Runtime.OpenWhisk
-config :worker, Worker.Domain.Ports.RuntimeTracker, adapter: Worker.Adapters.RuntimeTracker.ETS
-
-config :logger, :console,
-  format: "\n#####[$level] $time $metadata $message\n",
-  metadata: [:line]
-
-import_config "#{Mix.env()}.exs"
+config :worker, core: System.fetch_env!("CORE")

--- a/mix.exs
+++ b/mix.exs
@@ -33,8 +33,11 @@ defmodule FunlessWorker.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
-      mod: {Worker.Application, []}
+      extra_applications: [:logger, :inets],
+      mod: {Worker.Application, []},
+      start_phases: [
+        core_connect: Mix.env()
+      ]
     ]
   end
 


### PR DESCRIPTION
This PR adds the runtime env var CORE so we can specify a the node name of a core instance.
It adds a start phase so it can execute Node.connect on the given variable.

The worker now is run as: `CORE=<core node> worker start`
