### PR TITLE
Improvements

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -21,3 +21,5 @@ import Config
 if config_env() == :prod do
   config :worker, core: System.fetch_env!("CORE")
 end
+
+config :worker, docker_host: Worker.Adapters.Runtime.OpenWhisk.docker_socket()

--- a/lib/worker/adapters/runtime/openwhisk/nif.ex
+++ b/lib/worker/adapters/runtime/openwhisk/nif.ex
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+defmodule Worker.Adapters.Runtime.OpenWhisk.Nif do
+  @moduledoc """
+  NIFs used to manipulate docker OpenWhisk runtimes.
+  """
+  use Rustler, otp_app: :worker, crate: :fn
+
+  #   Creates the `_runtime_name` container, with information taken from `_function`.
+  #   ## Parameters
+  #     - _function: Worker.Domain.Function struct, containing function information
+  #     - _runtime_name: name of the container that will be created
+  #     - _docker_host: path of the docker socket in the current system
+  @doc false
+  def prepare_runtime(_function, _runtime_name, _docker_host) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  #   Gets the logs of the `_runtime_name` container.
+  #   ## Parameters
+  #     - _runtime_name: name of the container
+  #     - _docker_host: path of the docker socket in the current system
+  @doc false
+  def runtime_logs(_runtime_name, _docker_host) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+
+  #   Removes the `_runtime_name` container.
+  #   ## Parameters
+  #     - _runtime_name: name of the container that will be removed
+  #     - _docker_host: path of the docker socket in the current system
+  @doc false
+  def cleanup_runtime(_runtime_name, _docker_host) do
+    :erlang.nif_error(:nif_not_loaded)
+  end
+end

--- a/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
+++ b/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
@@ -21,38 +21,11 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
     Docker adapter for runtime manipulation. The actual docker interaction is done by the Fn NIFs.
   """
   @behaviour Worker.Domain.Ports.Runtime
-  use Rustler, otp_app: :worker, crate: :fn
   require Logger
+
+  alias Worker.Adapters.Runtime.OpenWhisk.Nif
   alias Worker.Domain.FunctionStruct
   alias Worker.Domain.RuntimeStruct
-
-  #   Creates the `_runtime_name` container, with information taken from `_function`.
-  #   ## Parameters
-  #     - _function: Worker.Domain.Function struct, containing function information
-  #     - _runtime_name: name of the container that will be created
-  #     - _docker_host: path of the docker socket in the current system
-  @doc false
-  def prepare_runtime(_function, _runtime_name, _docker_host) do
-    :erlang.nif_error(:nif_not_loaded)
-  end
-
-  #   Gets the logs of the `_runtime_name` container.
-  #   ## Parameters
-  #     - _runtime_name: name of the container
-  #     - _docker_host: path of the docker socket in the current system
-  @doc false
-  def runtime_logs(_runtime_name, _docker_host) do
-    :erlang.nif_error(:nif_not_loaded)
-  end
-
-  #   Removes the `_runtime_name` container.
-  #   ## Parameters
-  #     - _runtime_name: name of the container that will be removed
-  #     - _docker_host: path of the docker socket in the current system
-  @doc false
-  def cleanup_runtime(_runtime_name, _docker_host) do
-    :erlang.nif_error(:nif_not_loaded)
-  end
 
   @doc """
     Checks the DOCKER_HOST environment variable for the docker socket path. If an incorrect path is found, the default is used instead.
@@ -85,7 +58,7 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
 
     Logger.info("OpenWhisk Runtime: Creating runtime for function '#{function.name}'")
 
-    prepare_runtime(function, runtime_name, socket)
+    Nif.prepare_runtime(function, runtime_name, socket)
 
     receive do
       {:ok, runtime = %RuntimeStruct{host: host, port: port}} ->
@@ -151,7 +124,7 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
   @impl true
   def cleanup(runtime) do
     Logger.info("OpenWhisk Runtime: Removing runtime '#{runtime.name}'")
-    cleanup_runtime(runtime.name, docker_socket())
+    Nif.cleanup_runtime(runtime.name, docker_socket())
 
     receive do
       :ok -> {:ok, runtime}

--- a/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
+++ b/lib/worker/adapters/runtime/openwhisk/openwhisk.ex
@@ -54,7 +54,7 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
   """
   @impl true
   def prepare(%FunctionStruct{} = function, runtime_name) do
-    socket = docker_socket()
+    {:ok, socket} = Application.fetch_env(:worker, :docker_host)
 
     Logger.info("OpenWhisk Runtime: Creating runtime for function '#{function.name}'")
 
@@ -123,8 +123,10 @@ defmodule Worker.Adapters.Runtime.OpenWhisk do
   """
   @impl true
   def cleanup(runtime) do
+    {:ok, socket} = Application.fetch_env(:worker, :docker_host)
+
     Logger.info("OpenWhisk Runtime: Removing runtime '#{runtime.name}'")
-    Nif.cleanup_runtime(runtime.name, docker_socket())
+    Nif.cleanup_runtime(runtime.name, socket)
 
     receive do
       :ok -> {:ok, runtime}

--- a/native/fn/src/init.rs
+++ b/native/fn/src/init.rs
@@ -21,7 +21,7 @@ mod nif;
 pub mod utils;
 
 rustler::init!(
-    "Elixir.Worker.Adapters.Runtime.OpenWhisk",
+    "Elixir.Worker.Adapters.Runtime.OpenWhisk.Nif",
     [
         nif::prepare_runtime,
         nif::runtime_logs,


### PR DESCRIPTION
This PR closes #13 and #26.
`Adapters.Runtime.OpenWhisk` has also been split in the main module and a `.Nif` submodule for NIFs.

Logging in `create_image` has been removed (no need to follow image pulling process).