### PR TITLE
Split CI jobs in test-elixir, test-rust, license and linter

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Worker CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  license:
+    name: Check license headers
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Check License Header
+        uses: apache/skywalking-eyes@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Worker CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  linter:
+    name: Linter and formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: 1.13
+          otp-version: 24.0
+
+      - name: Install Dependencies
+        run: mix deps.get
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Run Mix Credo
+        run: mix credo --strict

--- a/.github/workflows/test-elixir.yml
+++ b/.github/workflows/test-elixir.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-name: Funless CI
+name: Worker CI
 
 on:
   push:
@@ -24,18 +24,13 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: Check and Test
+  test:
+    name: Test Elixir
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Check License Header
-        uses: apache/skywalking-eyes@main
 
       - name: Setup elixir
         uses: erlef/setup-beam@v1
@@ -46,23 +41,5 @@ jobs:
       - name: Install Dependencies
         run: mix deps.get
 
-      - name: Check formatting
-        run: mix format --check-formatted
-
-      - name: Run Mix Credo
-        run: mix credo --strict
-
       - name: Run Elixir Tests
         run: mix test
-
-      - name: Build FN rust module
-        run: cargo build --verbose
-        working-directory: native/fn
-
-      - name: Run cargo clippy on FN
-        run: cargo clippy --verbose
-        working-directory: native/fn
-
-      - name: Run FN tests
-        run: cargo test --verbose
-        working-directory: native/fn

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Worker CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test Rust
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build FN rust module
+        run: cargo build --verbose
+        working-directory: native/fn
+
+      - name: Run cargo clippy on FN
+        run: cargo clippy --verbose
+        working-directory: native/fn
+
+      - name: Run FN tests
+        run: cargo test --verbose
+        working-directory: native/fn


### PR DESCRIPTION
This PR splits the single CI job (`check.yml`) in four separate jobs to be executed in parallel.
